### PR TITLE
Resolve transaction update date, improve CustomButton theming, and bump version

### DIFF
--- a/lib/features/transactions/data/datasource/transaction_api.dart
+++ b/lib/features/transactions/data/datasource/transaction_api.dart
@@ -310,8 +310,6 @@ class TransactionsApi {
       final categoryId = categoryRows.first['id'] as String;
 
       final trType = transactionType?.value ?? TransactionType.expense.value;
-      final dateIso = date?.toUtc().toIso8601String() ??
-          DateTime.now().toUtc().toIso8601String();
       final nowIso = DateTime.now().toUtc().toIso8601String();
 
       await powersync.db.writeTransaction((tx) async {
@@ -329,6 +327,10 @@ class TransactionsApi {
         final oldType = old['transaction_type']?.toString();
         final oldCategoryId = old['category_id'] as String?;
         final oldAmount = _numFromValue(old['amount']);
+        final existingDateRaw = old['date']?.toString();
+        final resolvedDateIso = date?.toUtc().toIso8601String() ??
+            existingDateRaw ??
+            DateTime.now().toUtc().toIso8601String();
 
         // 1. Update the transaction
         await tx.execute(
@@ -339,7 +341,7 @@ class TransactionsApi {
           [
             validDescription,
             amountNumeric,
-            dateIso,
+            resolvedDateIso,
             categoryId,
             trType,
             transactionId,

--- a/lib/widgets/custom_button.dart
+++ b/lib/widgets/custom_button.dart
@@ -52,6 +52,16 @@ class CustomButton extends StatefulWidget {
 class _CustomButtonState extends State<CustomButton> {
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final resolvedBackgroundColor = widget.backgroundColor ?? AppTheme.primaryGreen;
+    final isOutlinedStyle =
+        resolvedBackgroundColor == theme.cardColor ||
+            resolvedBackgroundColor == Colors.transparent;
+    final themedOutlineColor =
+        theme.brightness == Brightness.dark ? Colors.white : Colors.black;
+    final contentColor =
+        isOutlinedStyle ? themedOutlineColor : CustomButton.buttonTextColor;
+
     return SizedBox(
       width: widget.width ?? double.infinity,
       height: widget.height ?? 5.5.h,
@@ -59,16 +69,19 @@ class _CustomButtonState extends State<CustomButton> {
         onPressed: widget.onPressed,
         style: ButtonStyle(
           backgroundColor: WidgetStatePropertyAll(
-            widget.backgroundColor ?? AppTheme.primaryGreen,
+            resolvedBackgroundColor,
           ),
+          foregroundColor: WidgetStatePropertyAll(contentColor),
           elevation: const WidgetStatePropertyAll(0),
           side: WidgetStatePropertyAll(
-            widget.backgroundColor == AppTheme.primaryGreen ||
-                    widget.backgroundColor == Colors.red
+            resolvedBackgroundColor == AppTheme.primaryGreen ||
+                    resolvedBackgroundColor == Colors.red
                 ? BorderSide.none
                 : BorderSide(
                     color: widget.borderColor ??
-                        Theme.of(context).colorScheme.onPrimary,
+                        (isOutlinedStyle
+                            ? themedOutlineColor
+                            : theme.colorScheme.onPrimary),
                   ),
           ),
           shape: WidgetStatePropertyAll(
@@ -83,22 +96,22 @@ class _CustomButtonState extends State<CustomButton> {
                 height: 6.w,
                 width: 6.w,
                 child: CircularProgressIndicator(
-                  color: CustomButton.buttonTextColor,
+                  color: contentColor,
                 ),
               )
-            : _buildChild(),
+            : _buildChild(contentColor),
       ),
     );
   }
 
-  Widget _buildChild() {
+  Widget _buildChild(Color contentColor) {
     final icon = widget.icon;
     final text = widget.text;
 
     if (icon != null && (text == null || text.isEmpty)) {
       return Icon(
         icon,
-        color: widget.iconColor ?? CustomButton.buttonTextColor,
+        color: widget.iconColor ?? contentColor,
       );
     }
 
@@ -109,7 +122,7 @@ class _CustomButtonState extends State<CustomButton> {
         children: [
           Icon(
             icon,
-            color: widget.iconColor ?? CustomButton.buttonTextColor,
+            color: widget.iconColor ?? contentColor,
           ),
           SizedBox(width: 2.w),
           Text(
@@ -117,7 +130,7 @@ class _CustomButtonState extends State<CustomButton> {
             style: TextStyle(
               fontSize: 15.5.sp,
               fontWeight: FontWeight.w900,
-              color: CustomButton.buttonTextColor,
+              color: contentColor,
             ),
           ),
         ],
@@ -129,7 +142,7 @@ class _CustomButtonState extends State<CustomButton> {
       style: TextStyle(
         fontSize: 15.5.sp,
         fontWeight: FontWeight.w900,
-        color: CustomButton.buttonTextColor,
+        color: contentColor,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.5.0+18
+version: 1.5.1+19
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
### Motivation
- Ensure transaction updates preserve an existing stored date when the new date is not provided to avoid unintentionally overwriting it with now.
- Make `CustomButton` adapt its foreground and border colors to the current `Theme` and to outlined/transparent backgrounds for correct contrast in dark/light modes.
- Bump package version to reflect the changes.

### Description
- In `TransactionsApi`, preserve the existing transaction `date` when updating by reading `old['date']` and computing `resolvedDateIso = date?.toUtc().toIso8601String() ?? existingDateRaw ?? DateTime.now().toUtc().toIso8601String()` and use it in the `UPDATE` statement.
- Add local `resolvedBackgroundColor`, `isOutlinedStyle`, `themedOutlineColor`, and `contentColor` resolution in `CustomButton` to set `backgroundColor`, `foregroundColor`, border `color`, and progress/icon/text colors consistently with the app `Theme` and outlined styles.
- Update `CustomButton._buildChild` signature to accept `contentColor` and use it for icons and text when no explicit `iconColor` is provided.
- Bump `version` in `pubspec.yaml` from `1.5.0+18` to `1.5.1+19`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48f51be1c832e885db5fa51e55173)